### PR TITLE
useframev2

### DIFF
--- a/src/ManchesterAnalyzer.cpp
+++ b/src/ManchesterAnalyzer.cpp
@@ -12,6 +12,7 @@
 ManchesterAnalyzer::ManchesterAnalyzer() : mSettings( new ManchesterAnalyzerSettings() ), Analyzer2(), mSimulationInitilized( false )
 {
     SetAnalyzerSettings( mSettings.get() );
+    UseFrameV2();
 }
 
 ManchesterAnalyzer::~ManchesterAnalyzer()


### PR DESCRIPTION
This won't build until the new UseFrameV2(); Function has become an official part of the SDK. In the meantime, do not use `UseFrameV2();`, as it will fail to build.